### PR TITLE
Metric collection systems introduced 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 ### logo ###
 BotLogo.png
 BotDescriptionLogo.gif
+
+### Screenshots ###
+/screenshots

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -178,6 +178,20 @@
             <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bot/src/main/java/edu/java/bot/command/HelpCommand.java
+++ b/bot/src/main/java/edu/java/bot/command/HelpCommand.java
@@ -2,6 +2,8 @@ package edu.java.bot.command;
 
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
@@ -12,6 +14,21 @@ import org.springframework.stereotype.Component;
 public class HelpCommand implements BaseCommand {
     @Autowired
     FunctionalCommandList functionalCommandList;
+
+    private final Counter counter;
+
+    public HelpCommand() {
+        counter = null;
+    }
+
+    @Autowired
+    public HelpCommand(MeterRegistry meterRegistry) {
+        counter = Counter
+            .builder("Telegram_messages_handled_total")
+            .description("Counts how many times the /help command has been processed")
+            .tags("command", command())
+            .register(meterRegistry);
+    }
 
     @Override
     public String command() {
@@ -29,6 +46,7 @@ public class HelpCommand implements BaseCommand {
 
     @Override
     public SendMessage handle(Update update) {
+        counter.increment();
         // Writing of list of commands
         List<FunctionalCommand> commands = functionalCommandList.getFunctionalCommandList();
         StringBuilder stringBuilder = new StringBuilder(description());

--- a/bot/src/main/java/edu/java/bot/command/StopCommand.java
+++ b/bot/src/main/java/edu/java/bot/command/StopCommand.java
@@ -3,6 +3,8 @@ package edu.java.bot.command;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,22 @@ public class StopCommand implements BaseCommand {
     @Autowired
     private ScrapperClient scrapperClient;
 
+    private final Counter counter;
+
+    public StopCommand(Counter counter, ScrapperClient scrapperClient) {
+        this.scrapperClient = scrapperClient;
+        this.counter = counter;
+    }
+
+    @Autowired
+    public StopCommand(MeterRegistry meterRegistry) {
+        counter = Counter
+            .builder("Telegram_messages_handled_total")
+            .description("Counts how many times the /stop command has been processed")
+            .tags("command", "/stop")
+            .register(meterRegistry);
+    }
+
     @Override
     public String command() {
         return "close";
@@ -20,6 +38,7 @@ public class StopCommand implements BaseCommand {
 
     @Override
     public SendMessage handle(Update update) {
+        counter.increment();
         scrapperClient.deleteTgChatId(update.myChatMember().chat().id());
         return null;
     }

--- a/bot/src/main/java/edu/java/bot/command/UnknownCommand.java
+++ b/bot/src/main/java/edu/java/bot/command/UnknownCommand.java
@@ -2,6 +2,9 @@ package edu.java.bot.command;
 
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -10,6 +13,21 @@ import org.springframework.stereotype.Component;
 @SuppressWarnings("DefaultAnnotationParam")
 @Order(Ordered.LOWEST_PRECEDENCE)
 public class UnknownCommand implements BaseCommand {
+    private final Counter counter;
+
+    public UnknownCommand(Counter counter) {
+        this.counter = counter;
+    }
+
+    @Autowired
+    public UnknownCommand(MeterRegistry meterRegistry) {
+        counter = Counter
+            .builder("Telegram_messages_handled_total")
+            .description("Counts how many times the /unknown command has been processed")
+            .tags("command", "/unknown")
+            .register(meterRegistry);
+    }
+
     @Override
     public String command() {
         return "/";
@@ -17,6 +35,7 @@ public class UnknownCommand implements BaseCommand {
 
     @Override
     public SendMessage handle(Update update) {
+        counter.increment();
         // End tracking link
         return new SendMessage(update.message().chat().id(),
             """

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -58,3 +58,29 @@ springdoc:
 
 scrapper:
   baseUrl: http://localhost:8080
+
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: info,health,prometheus
+      base-path: /
+      path-mapping:
+          health: health
+          prometheus: metrics
+  endpoint:
+    info:
+      enabled: true
+    health:
+      enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  labels:
+    application: ${spring.application.name}
+  server:
+    port: 8091

--- a/bot/src/test/java/edu/java/bot/command/ListCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/ListCommandTest.java
@@ -7,6 +7,7 @@ import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.model.responseDTO.LinkResponse;
 import edu.java.bot.model.responseDTO.ListLinksResponse;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,8 @@ import static org.mockito.Mockito.when;
 class ListCommandTest {
     @Mock
     ScrapperClient scrapperClient;
+    @Mock
+    Counter counter;
     @InjectMocks
     ListCommand listCommand;
 

--- a/bot/src/test/java/edu/java/bot/command/StartCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/StartCommandTest.java
@@ -5,6 +5,7 @@ import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -17,6 +18,8 @@ import static org.mockito.Mockito.when;
 class StartCommandTest {
     @Mock
     ScrapperClient scrapperClient;
+    @Mock
+    Counter counter;
     @InjectMocks
     StartCommand startCommand;
 

--- a/bot/src/test/java/edu/java/bot/command/StopCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/StopCommandTest.java
@@ -6,6 +6,7 @@ import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -22,6 +23,8 @@ class StopCommandTest {
 
     @Mock
     ScrapperClient scrapperClient;
+    @Mock
+    Counter counter;
     @InjectMocks
     StopCommand stopCommand;
 

--- a/bot/src/test/java/edu/java/bot/command/TrackCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/TrackCommandTest.java
@@ -6,6 +6,7 @@ import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.model.requestDTO.LinkRequest;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -20,6 +21,8 @@ import static org.mockito.Mockito.when;
 class TrackCommandTest {
     @Mock
     ScrapperClient scrapperClient;
+    @Mock
+    Counter counter;
     @InjectMocks
     TrackCommand trackCommand;
 

--- a/bot/src/test/java/edu/java/bot/command/UnknownCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/UnknownCommandTest.java
@@ -4,22 +4,24 @@ import com.pengrad.telegrambot.model.Chat;
 import com.pengrad.telegrambot.model.Message;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
+import io.micrometer.core.instrument.Counter;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class UnknownCommandTest {
+    Counter counter = mock(Counter.class);
 
     @Test
     public void testCommand() {
-        UnknownCommand unknownCommand = new UnknownCommand();
+        UnknownCommand unknownCommand = new UnknownCommand(counter);
         assertEquals("/", unknownCommand.command());
     }
 
     @Test
     public void testHandle() {
-        UnknownCommand unknownCommand = new UnknownCommand();
+        UnknownCommand unknownCommand = new UnknownCommand(counter);
 
         Update mockUpdate = mock(Update.class);
         Message mockMessage = mock(Message.class);

--- a/bot/src/test/java/edu/java/bot/command/UntrackCommandTest.java
+++ b/bot/src/test/java/edu/java/bot/command/UntrackCommandTest.java
@@ -6,6 +6,7 @@ import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.SendMessage;
 import edu.java.bot.model.requestDTO.LinkRequest;
 import edu.java.bot.web.ScrapperClient;
+import io.micrometer.core.instrument.Counter;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -19,6 +20,8 @@ import static org.mockito.Mockito.when;
 class UntrackCommandTest {
     @Mock
     ScrapperClient scrapperClient;
+    @Mock
+    Counter counter;
     @InjectMocks
     UntrackCommand untrackCommand;
 

--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
       - postgresql:/var/lib/postgresql/data
     networks:
       - backend
-      
+
   liquibase-migrations:
     image: liquibase/liquibase:4.25
     depends_on:
@@ -26,8 +26,8 @@ services:
     volumes:
         - ./migrations:/liquibase/changelog
     networks:
-        - backend  
-  
+        - backend
+
   zookeeper:
     image: confluentinc/cp-zookeeper:7.3.2
     hostname: zookeeper
@@ -42,7 +42,7 @@ services:
       - zookeeper_data:/var/lib/zookeeper
     networks:
       - backend
-      
+
   kafka:
     image: confluentinc/cp-kafka:7.3.2
     hostname: kafka
@@ -72,10 +72,35 @@ services:
     networks:
       - backend
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus:/prometheus
+    networks:
+      - backend
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana:/var/lib/grafana
+    networks:
+      - backend
+
 volumes:
   postgresql: { }
   zookeeper_data: { }
   kafka_data: { }
+  prometheus: { }
+  grafana: { }
 
 networks:
   backend: { }

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'bot'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['host.docker.internal:8091']
+
+  - job_name: 'scrapper'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['host.docker.internal:8081']

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -157,6 +157,20 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- metrics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scrapper/src/main/java/edu/java/DB/jdbc/DAO/LinkDAO.java
+++ b/scrapper/src/main/java/edu/java/DB/jdbc/DAO/LinkDAO.java
@@ -81,7 +81,7 @@ public class LinkDAO {
     }
 
     public List<LinkDTO> findAllLinksWithFilter() {
-        return jdbcTemplate.query("SELECT * FROM Link WHERE last_seen < NOW() - INTERVAL '1 minutes'",
+        return jdbcTemplate.query("SELECT * FROM Link WHERE last_seen < NOW() - INTERVAL '5 minutes'",
             (rs, rowNum) -> {
                 try {
                     return new LinkDTO(

--- a/scrapper/src/main/java/edu/java/DB/jpa/repository/LinkRepository.java
+++ b/scrapper/src/main/java/edu/java/DB/jpa/repository/LinkRepository.java
@@ -26,7 +26,7 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
     @Query(value = """
             SELECT *
             FROM link
-            WHERE last_seen < NOW() - INTERVAL '1' MINUTE
+            WHERE last_seen < NOW() - INTERVAL '5' MINUTE
             """, nativeQuery = true)
     List<Link> findAllLinksWithFilter();
 

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -64,3 +64,29 @@ springdoc:
 
 bot:
   baseUrl: http://localhost:8090
+
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: info,health,prometheus
+      base-path: /
+      path-mapping:
+        health: health
+        prometheus: metrics
+  endpoint:
+    info:
+      enabled: true
+    health:
+      enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+  labels:
+    application: ${spring.application.name}
+  server:
+    port: 8081

--- a/scrapper/src/test/java/edu/java/scrapper/DB/jdbc/LinkDAOTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/DB/jdbc/LinkDAOTest.java
@@ -187,8 +187,8 @@ public class LinkDAOTest extends IntegrationTest {
         LinkDTO thirdLink = connectionLink.findLinkByURI(
             URI.create("https://api.github.com/repos/ScherbachenyaMIK/java-course-2023-backend"));
 
-        connectionLink.updateLink(firstLink.id(), now, now.minusMinutes(3));
-        connectionLink.updateLink(secondLink.id(), now, now.minusMinutes(4));
+        connectionLink.updateLink(firstLink.id(), now, now.minusMinutes(7));
+        connectionLink.updateLink(secondLink.id(), now, now.minusMinutes(8));
         connectionLink.updateLink(thirdLink.id(), now, now.plusHours(1));
 
         firstLink = connectionLink.findLinkByURI(

--- a/scrapper/src/test/java/edu/java/scrapper/DB/jpa/LinkRepositoryTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/DB/jpa/LinkRepositoryTest.java
@@ -269,8 +269,8 @@ class LinkRepositoryTest extends IntegrationTest {
         link3.setLastUpdate(Timestamp.from(OffsetDateTime.now().toInstant()));
 
         link1.setLastSeen(Timestamp.from(OffsetDateTime.now().plusHours(1).toInstant()));
-        link2.setLastSeen(Timestamp.from(OffsetDateTime.now().minusMinutes(3).toInstant()));
-        link3.setLastSeen(Timestamp.from(OffsetDateTime.now().minusMinutes(4).toInstant()));
+        link2.setLastSeen(Timestamp.from(OffsetDateTime.now().minusMinutes(7).toInstant()));
+        link3.setLastSeen(Timestamp.from(OffsetDateTime.now().minusMinutes(8).toInstant()));
 
         linkRepository.save(link1);
         linkRepository.save(link2);


### PR DESCRIPTION
1. Delay
<details>

<summary>What wrong with delay?</summary>

Delay between requests to remote sources has been increased, because the system was quickly using up all github tokens.

</details>

2. Tasks
<details>

<summary>Results of task 3 from homework</summary>

Dashboard, with 3 views:

![Metrics Dashboard](https://github.com/user-attachments/assets/f99ef9d5-d5f4-49ab-9976-49a216558c5a)

And all requests for this views:
<details>

<summary>Memory usage:</summary>

![Query_mem_usage_per_time_unit](https://github.com/user-attachments/assets/8a1c9802-424b-4c8d-b57a-6ec5940f252f)

</details>

<details>

<summary>Garbage collector:</summary>

![Query_mem_alloc_for_gc](https://github.com/user-attachments/assets/706078ce-88f8-4eee-b832-73dcc6f91b99)

</details>

<details>

<summary>Http requests:</summary>

![Query_http_requests_metrics](https://github.com/user-attachments/assets/fffe00ec-976f-4ba6-82c7-4de585de0b5a)

</details>

</details>

<details>

<summary>Results of task 4 from homework</summary>

To accomplish this task I just add the following property to my queries, because when I configure Prometheus, I add 2 separate jobs:

![Request_upd](https://github.com/user-attachments/assets/35c22841-156b-48b4-95ac-8021eee1c2e6)

Dashboards, with separation on bot/scrapper/bot+scrapper jobs:

<details>

<summary>bot:</summary>

![Metrics Dashboard_bot](https://github.com/user-attachments/assets/693219bc-affa-4e63-9b92-3158743e61d1)

</details>

<details>

<summary>scrapper:</summary>

![Metrics Dashboard_scrapper](https://github.com/user-attachments/assets/caae453f-13ab-4036-a753-50ccf71fd9fe)

</details>

<details>

<summary>bot+scrapper:</summary>

![Metrics Dashboard_bot_scrapper](https://github.com/user-attachments/assets/c93e7228-e939-4780-8207-146dd00f67f8)

</details>

</details>

<details>

<summary>Results of task 5 from homework</summary>

Dashboard with new view:

![Metrics Dashboard_with_message_metrics](https://github.com/user-attachments/assets/d6bd5359-c391-46bc-86d4-cffce6f13f59)

Query for this view:

<details>

<summary>Query:</summary>

![Query_telegram_mes_hand_total](https://github.com/user-attachments/assets/f2088221-d613-431b-a217-7c6d2e126811)

</details>

</details>

</details>

3. One more fix:
<details>

<summary>Fixed metrics units</summary>

There views with configured metrics units:

![Metrics Dashboard_with_correct_units](https://github.com/user-attachments/assets/6a9a9013-b6ee-4230-8a45-fb95c7198e04)

</details>
